### PR TITLE
feat: twigo でworktree先からmainに戻ってtwig addするように変更

### DIFF
--- a/HOME/.config/fish/functions/twigo.fish
+++ b/HOME/.config/fish/functions/twigo.fish
@@ -1,5 +1,6 @@
 function twigo
     set -l branch $argv[1]
+    set -l main_dir (dirname (git rev-parse --path-format=absolute --git-common-dir))
     set -l existing_path (git worktree list --porcelain | awk -v branch="refs/heads/$branch" '
         /^worktree / { path = substr($0, 10) }
         $0 == "branch " branch { print path }
@@ -8,7 +9,8 @@ function twigo
     if test -n "$existing_path"
         cd $existing_path
     else
-        set -l dir (twig add $argv -q)
+        cd $main_dir
+        and set -l dir (twig add $argv -q)
         and cd $dir
     end
 


### PR DESCRIPTION
## Summary
- worktree先のディレクトリから `twigo` を実行した際、`git rev-parse --git-common-dir` でmainブランチのディレクトリを特定し、そこに移動してから `twig add` を実行するように変更

## Test plan
- [ ] mainブランチのディレクトリから `twigo <新規ブランチ>` で正常にworktreeが作成されることを確認
- [ ] worktree先のディレクトリから `twigo <新規ブランチ>` で正常にworktreeが作成されることを確認
- [ ] worktree先のディレクトリから `twigo <既存ブランチ>` で既存worktreeに移動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directory navigation behavior in the twigo command to properly handle worktree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->